### PR TITLE
Add support for CWEs, CAPECs, and CPEs

### DIFF
--- a/ioc/ioc.go
+++ b/ioc/ioc.go
@@ -48,12 +48,6 @@ func GetIOCs(data string, getFangedIOCs bool, standardizeDefangs bool) []*IOC {
 		}
 	}
 
-	for _, i := range iocs {
-		if i.Type == CPE {
-			iocs = []*IOC{i}
-		}
-	}
-
 	return iocs
 }
 

--- a/ioc/ioc.go
+++ b/ioc/ioc.go
@@ -2,10 +2,9 @@ package ioc
 
 import (
 	"context"
+	"github.com/vertoforce/multiregex"
 	"io"
 	"io/ioutil"
-
-	"github.com/vertoforce/multiregex"
 )
 
 const (
@@ -46,6 +45,12 @@ func GetIOCs(data string, getFangedIOCs bool, standardizeDefangs bool) []*IOC {
 
 				iocs = append(iocs, ioc)
 			}
+		}
+	}
+
+	for _, i := range iocs {
+		if i.Type == CPE {
+			iocs = []*IOC{i}
 		}
 	}
 

--- a/ioc/ioc_test.go
+++ b/ioc/ioc_test.go
@@ -131,6 +131,17 @@ func TestGetIOCs(t *testing.T) {
 		{"CVE-2100-0000", []*IOC{{"CVE-2100-0000", CVE}}},
 		{"CVE-2016-00000", []*IOC{{"CVE-2016-00000", CVE}}},
 		{"CVE-20100-0000", nil},
+		{"CAPEC-13", []*IOC{{"CAPEC-13", CAPEC}}},
+		{"CWE-200", []*IOC{{"CWE-200", CWE}}},
+		{"cpe:2.3:a:openbsd:openssh:7.5:-:*:*:*:*:*:*", []*IOC{{"cpe:2.3:a:openbsd:openssh:7.5:-:*:*:*:*:*:*", CPE}}},
+		{"cpe:/a:openbsd:openssh:7.5:-", []*IOC{{"cpe:/a:openbsd:openssh:7.5:-", CPE}}},
+		{"cpe:/a:microsoft:internet_explorer:8.%02:sp%01", []*IOC{{"cpe:/a:microsoft:internet_explorer:8.%02:sp%01", CPE}}},
+		{"cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003~x64~", []*IOC{{"cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003~x64~", CPE}}},
+		{"cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*", []*IOC{{"cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*", CPE}}},
+		{"cpe:2.3:a:microsoft:internet_explorer:8.*:sp?:*:*:*:*:*:*", []*IOC{{"cpe:2.3:a:microsoft:internet_explorer:8.*:sp?:*:*:*:*:*:*", CPE}}},
+		{"cpe:2.3:a:hp:insight:7.4.0.1570:-:*:*:online:win2003:x64:*", []*IOC{{"cpe:2.3:a:hp:insight:7.4.0.1570:-:*:*:online:win2003:x64:*", CPE}}},
+		{"cpe:2.3:a:hp:openview_network_manager:7.51:*:*:*:*:linux:*:*", []*IOC{{"cpe:2.3:a:hp:openview_network_manager:7.51:*:*:*:*:linux:*:*", CPE}}},
+		{"cpe:2.3:a:foo\\\\bar:big\\$money_2010:*:*:*:*:special:ipod_touch:80gb:*", []*IOC{{"cpe:2.3:a:foo\\\\bar:big\\$money_2010:*:*:*:*:special:ipod_touch:80gb:*", CPE}}},
 
 		// Misc
 		{"1.1.1.1 google.com 1.1.1.1", []*IOC{

--- a/ioc/regexs.go
+++ b/ioc/regexs.go
@@ -23,8 +23,8 @@ var iocRegexes = map[Type]*regexp.Regexp{
 	// Emails
 	Email: regexp.MustCompile(`[A-Za-z0-9_.]+((\ ?(\[|\()?\ ?@\ ?(\)|\])?\ ?)|(\ ?(\[|\()\ ?[aA][tT]\ ?(\)|\])\ ?))[0-9a-z.-]+`),
 	// IPs
-	IPv4: regexp.MustCompile(`(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)([\[\(]?\.[\]\)]?)){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)`),
-	IPv6: regexp.MustCompile(`(?:[a-f0-9]{1,4}:|:){2,7}(?:[a-f0-9]{1,4}|:)`),
+	IPv4: regexp.MustCompile(`(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)([\[\(]?\.[\]\)]?)){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b`),
+	IPv6: regexp.MustCompile(`(?:[a-f0-9]{1,4}:|:){2,7}(?:[a-f0-9]{1,4}|:)\b`),
 	// URLs
 	URL: regexp.MustCompile(`(\b((http|https|hxxp|hxxps|nntp|ntp|rdp|sftp|smtp|ssh|tor|webdav|xmpp)[[([]?\:\/\/[])]?[\S]+)\b)`),
 	// Files

--- a/ioc/regexs.go
+++ b/ioc/regexs.go
@@ -30,5 +30,9 @@ var iocRegexes = map[Type]*regexp.Regexp{
 	// Files
 	File: regexp.MustCompile(`(([\w\-]+)\.)+(docx|doc|csv|pdf|xlsx|xls|rtf|txt|pptx|ppt|pages|keynote|numbers|exe|dll|jar|flv|swf|jpeg|jpg|gif|png|tiff|bmp|plist|app|pkg|html|htm|php|jsp|asp|zip|zipx|7z|rar|tar|gz)`),
 	// Utility
-	CVE: regexp.MustCompile(`((CVE|cve)-\d{4}-\d{4,7})`),
+	CVE: regexp.MustCompile(`(?i)CVE-\d{4}-\d{4,7}`),
+	CAPEC: regexp.MustCompile(`(?i)CAPEC-\d+`),
+	CWE: regexp.MustCompile(`(?i)CWE-\d+`),
+	// support for URI and WFN CPE 2.2 and 2.3 bindings
+	CPE: regexp.MustCompile(`(?i)cpe(:2[.]3)?:[/]?[aoh*\-](:[?*]?([a-z0-9\-._]|([\\][\\?*!"#$%&'()+,/:;<=>@[\]^{|}~])|[%~])*[?*\-]?){0,5}(:([a-z]{2,3}(-([a-z]{2}|[0-9]{3}))?)|[*\-])?(:[?*]?([a-z0-9\-._]|([\\][\\?*!"#$%&'()+,/:;<=>@[\]^{|}~])|[%~])*[?*\-]?){0,5}`),
 }

--- a/ioc/type_string.go
+++ b/ioc/type_string.go
@@ -21,11 +21,12 @@ func _() {
 	_ = x[URL-10]
 	_ = x[File-11]
 	_ = x[CVE-12]
+	_ = x[CAPEC-13]
 }
 
-const _Type_name = "UnknownBitcoinMD5SHA1SHA256SHA512DomainEmailIPv4IPv6URLFileCVE"
+const _Type_name = "UnknownBitcoinMD5SHA1SHA256SHA512DomainEmailIPv4IPv6URLFileCVECAPEC"
 
-var _Type_index = [...]uint8{0, 7, 14, 17, 21, 27, 33, 39, 44, 48, 52, 55, 59, 62}
+var _Type_index = [...]uint8{0, 7, 14, 17, 21, 27, 33, 39, 44, 48, 52, 55, 59, 62, 67}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {

--- a/ioc/types.go
+++ b/ioc/types.go
@@ -37,6 +37,9 @@ const (
 	URL
 	File
 	CVE
+	CAPEC
+	CWE
+	CPE
 )
 
 // Types of all IOCs
@@ -53,6 +56,9 @@ var Types = []Type{
 	URL,
 	File,
 	CVE,
+	CAPEC,
+	CWE,
+	CPE,
 }
 
 // -- []IOC helpers --


### PR DESCRIPTION
_CWEs are Common Weakness Enumerations, CAPECs are Common Attack Pattern and Enumeration Classifications, and CPEs are Common Platform Enumerations._

I've also added the ignore case flags so these regexes are case-insensitive.